### PR TITLE
Include Bluemix CLI in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,6 +44,17 @@ Vagrant.configure(2) do |config|
     apt-get install -y git python-pip python-dev build-essential
     pip install --upgrade pip
     apt-get -y autoremove
+
+    echo "\n******************************"
+    echo " Installing Bluemix CLI"
+    echo "******************************\n"
+    wget -q -O - https://clis.ng.bluemix.net/download/bluemix-cli/latest/linux64 | tar xzv
+    cd Bluemix_CLI/
+    ./install_bluemix_cli
+    cd ..
+    rm -fr Bluemix_CLI/
+    bluemix config --usage-stats-collect false
+
     # Make vi look nice
     sudo -H -u ubuntu echo "colorscheme desert" > ~/.vimrc
     # Install app dependencies


### PR DESCRIPTION
Please do a `vagrant up --provision` to take effect.