### PR TITLE
Tuned timeout and recycle to prevent DB connection loss.

### DIFF
--- a/app/static/js/rest_api.js
+++ b/app/static/js/rest_api.js
@@ -26,6 +26,7 @@ $(function () {
     }
 
     function clear_list() {
+        $("#flash_message").empty();
         $("#search_results").empty();
     }
 

--- a/config.py
+++ b/config.py
@@ -11,6 +11,9 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 
 SQLALCHEMY_DATABASE_URI = get_database_uri()
 SQLALCHEMY_TRACK_MODIFICATIONS = False
+SQLALCHEMY_POOL_SIZE = 5
+SQLALCHEMY_POOL_TIMEOUT = 500
+SQLALCHEMY_POOL_RECYCLE = 300
 
 SECRET_KEY = 'secret-for-dev-only'
 LOGGING_LEVEL = logging.INFO


### PR DESCRIPTION
I deployed the modified version to [`dev`](https://nyu-promotion-service-s18.mybluemix.net/). However, [`prod`](https://nyu-promotion-service-s18-prod.mybluemix.net/) remains the old version. 

When you see this description, go to the two URLs, and do click the `search` button, 
- In  [`dev`](https://nyu-promotion-service-s18.mybluemix.net/) you should succeed 
- In [`prod`](https://nyu-promotion-service-s18-prod.mybluemix.net/) you are supposed to see an error telling you the database connection is lost. **You should succeed within two retries**.